### PR TITLE
Focus the test suite to find the py33 problem.

### DIFF
--- a/handroll/tests/test_extensions.py
+++ b/handroll/tests/test_extensions.py
@@ -39,7 +39,8 @@ class TestExtension(TestCase):
     def test_connects_to_frontmatter_loaded(self):
         class FrontmatterLoader(Extension):
             handle_frontmatter_loaded = True
-        FrontmatterLoader(None)
+        extension = FrontmatterLoader(None)
+        self.assertTrue(extension.handle_frontmatter_loaded)
         self.assertRaises(
             NotImplementedError, signals.frontmatter_loaded.send,
             'a_source_file', frontmatter={})
@@ -53,6 +54,7 @@ class TestExtension(TestCase):
         class PostComposer(Extension):
             handle_post_composition = True
         director = mock.Mock()
-        PostComposer(None)
+        extension = PostComposer(None)
+        self.assertTrue(extension.handle_post_composition)
         self.assertRaises(
             NotImplementedError, signals.post_composition.send, director)

--- a/handroll/tests/test_extensions.py
+++ b/handroll/tests/test_extensions.py
@@ -44,6 +44,7 @@ class TestExtension(TestCase):
         self.assertRaises(
             NotImplementedError, signals.frontmatter_loaded.send,
             'a_source_file', frontmatter={})
+        signals.frontmatter_loaded.receivers.clear()
 
     @mock.patch('handroll.extensions.base.signals.post_composition')
     def test_post_composition_connection_default(self, post_composition):
@@ -58,3 +59,4 @@ class TestExtension(TestCase):
         self.assertTrue(extension.handle_post_composition)
         self.assertRaises(
             NotImplementedError, signals.post_composition.send, director)
+        signals.post_composition.receivers.clear()

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ envlist = py26
 
 [testenv]
 deps = nose
-commands = nosetests handroll.tests.test_extensions
+commands = nosetests
            handroll -v sample
 
 [testenv:flake8]

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ envlist = py26
 
 [testenv]
 deps = nose
-commands = nosetests
+commands = nosetests handroll.tests.test_extension
            handroll -v sample
 
 [testenv:flake8]

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ envlist = py26
 
 [testenv]
 deps = nose
-commands = nosetests handroll.tests.test_extension
+commands = nosetests handroll.tests.test_extensions
            handroll -v sample
 
 [testenv:flake8]


### PR DESCRIPTION
blinker is failing on Travis on Python 3.3, but not locally for me. So this is a PR to test with Travis. I think this may be painful.